### PR TITLE
Simplify sharing client details

### DIFF
--- a/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectingState.cs
@@ -102,10 +102,13 @@ namespace Unity.BossRoom.ConnectionManagement
             var transport = (TashiNetworkTransport)m_ConnectionManager.NetworkManager.NetworkConfig.NetworkTransport;
             foreach (var user in m_LocalLobby.LobbyUsers.Values)
             {
-                transport.AddAddressBookEntry(user.AddressBookEntry.GetValueOrDefault());
-                if (user.IsHost)
+                if (user.AddressBookEntry is not null)
                 {
-                    transport.HostPublicKey = user.AddressBookEntry?.PublicKey;
+                    transport.AddAddressBookEntry(user.AddressBookEntry);
+                    if (user.IsHost)
+                    {
+                        transport.HostPublicKey = user.AddressBookEntry?.PublicKey;
+                    }
                 }
             }
         }

--- a/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/ClientConnectingState.cs
@@ -104,11 +104,7 @@ namespace Unity.BossRoom.ConnectionManagement
             {
                 if (user.AddressBookEntry is not null)
                 {
-                    transport.AddAddressBookEntry(user.AddressBookEntry);
-                    if (user.IsHost)
-                    {
-                        transport.HostPublicKey = user.AddressBookEntry?.PublicKey;
-                    }
+                    transport.AddAddressBookEntry(user.AddressBookEntry, user.IsHost);
                 }
             }
         }

--- a/Assets/Scripts/ConnectionManagement/ConnectionState/HostingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/HostingState.cs
@@ -162,11 +162,7 @@ namespace Unity.BossRoom.ConnectionManagement
             {
                 if (user.AddressBookEntry is not null)
                 {
-                    transport.AddAddressBookEntry(user.AddressBookEntry);
-                    if (user.IsHost)
-                    {
-                        transport.HostPublicKey = user.AddressBookEntry?.PublicKey;
-                    }
+                    transport.AddAddressBookEntry(user.AddressBookEntry, user.IsHost);
                 }
             }
         }

--- a/Assets/Scripts/ConnectionManagement/ConnectionState/HostingState.cs
+++ b/Assets/Scripts/ConnectionManagement/ConnectionState/HostingState.cs
@@ -160,10 +160,13 @@ namespace Unity.BossRoom.ConnectionManagement
             var transport = (TashiNetworkTransport)m_ConnectionManager.NetworkManager.NetworkConfig.NetworkTransport;
             foreach (var user in m_LocalLobby.LobbyUsers.Values)
             {
-                transport.AddAddressBookEntry(user.AddressBookEntry.GetValueOrDefault());
-                if (user.IsHost)
+                if (user.AddressBookEntry is not null)
                 {
-                    transport.HostPublicKey = user.AddressBookEntry?.PublicKey;
+                    transport.AddAddressBookEntry(user.AddressBookEntry);
+                    if (user.IsHost)
+                    {
+                        transport.HostPublicKey = user.AddressBookEntry?.PublicKey;
+                    }
                 }
             }
         }

--- a/Assets/Scripts/UnityServices/Lobbies/LocalLobby.cs
+++ b/Assets/Scripts/UnityServices/Lobbies/LocalLobby.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -252,12 +254,8 @@ namespace Unity.BossRoom.UnityServices.Lobbies
                     }
                 }
 
-                // LB FIXME: Consider serializing AddressBookEntry
-
                 string displayName = default;
-                IPAddress? boundAddress = default;
-                ushort boundPort = 0;
-                PublicKey? publicKey = default;
+                AddressBookEntry? addressBookEntry = null;
 
                 if (player.Data != null)
                 {
@@ -266,26 +264,12 @@ namespace Unity.BossRoom.UnityServices.Lobbies
                         displayName = displayNameObj.Value;
                     }
 
-                    if (player.Data.TryGetValue("BoundAddress", out var boundAddressObj))
+                    if (player.Data.TryGetValue("AddressBookEntry", out var addressBookEntryObject))
                     {
-                        IPAddress.TryParse(boundAddressObj.Value, out boundAddress);
-                    }
-
-                    if (player.Data.TryGetValue("BoundPort", out var boundPortObj))
-                    {
-                        ushort.TryParse(boundPortObj.Value, out boundPort);
-                    }
-
-                    if (player.Data.TryGetValue("PublicKey", out var publicKeyObj))
-                    {
-                        publicKey = PublicKey.FromDer(Convert.FromBase64String(publicKeyObj.Value));
+                        addressBookEntry = AddressBookEntry.Deserialize(addressBookEntryObject.Value);
                     }
                 }
 
-                if (boundAddress is null)
-                {
-                    continue;
-                }
                 // If the player isn't connected to Relay, get the most recent data that the lobby knows.
                 // (If we haven't seen this player yet, a new local representation of the player will have already been added by the LocalLobby.)
                 var incomingData = new LocalLobbyUser
@@ -293,11 +277,7 @@ namespace Unity.BossRoom.UnityServices.Lobbies
                     IsHost = lobby.HostId.Equals(player.Id),
                     DisplayName = displayName,
                     ID = player.Id,
-                    AddressBookEntry = new AddressBookEntry
-                    {
-                        Address = new IPEndPoint(boundAddress, boundPort),
-                        PublicKey = publicKey,
-                    }
+                    AddressBookEntry = addressBookEntry,
                 };
 
                 lobbyUsers.Add(incomingData.ID, incomingData);

--- a/Assets/Scripts/UnityServices/Lobbies/LocalLobbyUser.cs
+++ b/Assets/Scripts/UnityServices/Lobbies/LocalLobbyUser.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
-using JetBrains.Annotations;
 using Unity.Services.Lobbies.Models;
-using UnityEngine;
 using Tashi.ConsensusEngine;
 
 namespace Unity.BossRoom.UnityServices.Lobbies
@@ -149,18 +146,8 @@ namespace Unity.BossRoom.UnityServices.Lobbies
             if (AddressBookEntry is not null)
             {
                 result.Add(
-                    "PublicKey",
-                    new PlayerDataObject(PlayerDataObject.VisibilityOptions.Member,
-                        Convert.ToBase64String(AddressBookEntry?.PublicKey.AsDer()))
-                );
-
-                result.Add(
-                    "BoundAddress",
-                    new PlayerDataObject(PlayerDataObject.VisibilityOptions.Member, AddressBookEntry?.Address.Address.ToString()));
-
-                result.Add(
-                    "BoundPort",
-                    new PlayerDataObject(PlayerDataObject.VisibilityOptions.Member, AddressBookEntry?.Address.Port.ToString())
+                    "AddressBookEntry",
+                    new PlayerDataObject(PlayerDataObject.VisibilityOptions.Member, AddressBookEntry.Serialize())
                 );
             }
 


### PR DESCRIPTION
This relies on TNT's serialization and deserialization of address book entries rather than manually adding each field to the Unity Lobby player data.